### PR TITLE
Fix "KeyError ['title']" while loading playlists

### DIFF
--- a/melomaniac/gmusic/library.py
+++ b/melomaniac/gmusic/library.py
@@ -39,14 +39,14 @@ class Library(BaseLibrary):
                 if track_['source'] == '1':
                     # We need to find our track :-(
                     track_ = self._search_track_in_library(track_['trackId'])
+                if  'title' in track_:
+                    track = Track(
+                        self,
+                        track_['id'], track_['title'], track_['artist'], track_['album'],
+                        track_['trackNumber'], track_.get('discNumber', 0), metadata=track_
+                    )
 
-                track = Track(
-                    self,
-                    track_['id'], track_['title'], track_['artist'], track_['album'],
-                    track_['trackNumber'], track_.get('discNumber', 0), metadata=track_
-                )
-
-                playlist.add_track(track)
+                    playlist.add_track(track)
 
             playlists.append(playlist)
 


### PR DESCRIPTION
### Issue
`get_playlist()` was returning an error for tracks with no `'title'` field. 

```
$ melomaniac listen
- Loading config.
- Connecting to Google Play Music.
- Loading library.
- Loaded 454 albums, 4721 tracks
- Loading playlists.

              
  [KeyError]  
  'title'     
```

### Solution
Check for 'title' field in `track_` dictionary before trying to add track.